### PR TITLE
Filter out empty topic files

### DIFF
--- a/src/main/java/no/ssb/rawdata/avro/cloudstorage/GCSRawdataUtils.java
+++ b/src/main/java/no/ssb/rawdata/avro/cloudstorage/GCSRawdataUtils.java
@@ -97,7 +97,7 @@ class GCSRawdataUtils implements AvroRawdataUtils {
     Stream<Blob> listTopicFiles(String bucketName, String topic) {
         Page<Blob> page = storage.list(bucketName, Storage.BlobListOption.prefix(topic + "/"));
         Stream<Blob> stream = StreamSupport.stream(page.iterateAll().spliterator(), false);
-        return stream.filter(blob -> !blob.isDirectory());
+        return stream.filter(blob -> !blob.isDirectory() && blob.getSize() > 0);
     }
 
     @Override

--- a/src/main/java/no/ssb/rawdata/avro/filesystem/FilesystemRawdataUtils.java
+++ b/src/main/java/no/ssb/rawdata/avro/filesystem/FilesystemRawdataUtils.java
@@ -83,7 +83,7 @@ class FilesystemRawdataUtils implements AvroRawdataUtils {
             if (!topicFolder.toFile().isDirectory()) {
                 return map;
             }
-            Files.list(topicFolder).filter(path -> path.toFile().isFile()).forEach(path -> {
+            Files.list(topicFolder).filter(path -> path.toFile().isFile() && path.toFile().length() > 0).forEach(path -> {
                 long fromTimestamp = getFromTimestamp(path);
                 map.put(fromTimestamp, new FilesystemRawdataAvroFile(path));
             });


### PR DESCRIPTION
Attempts to workaround issue occurring when encountering empty .avro files. E.g:
```
java.lang.RuntimeException: java.io.IOException: Not a data file.
	at no.ssb.rawdata.avro.AvroRawdataConsumer.setDataFileReader(AvroRawdataConsumer.java:181)
	at no.ssb.rawdata.avro.AvroRawdataConsumer.receive(AvroRawdataConsumer.java:89)
	at no.ssb.rawdata.converter.core.ConverterExecutor.lambda$rawdataMessagesFlow$1(ConverterExecutor.java:122)
	at no.ssb.rawdata.converter.core.ConverterExecutor$$Lambda$729.000000003639B640.accept(Unknown Source)
	at io.reactivex.internal.operators.flowable.FlowableInternalHelper$SimpleGenerator.apply(FlowableInternalHelper.java:44)
	at io.reactivex.internal.operators.flowable.FlowableInternalHelper$SimpleGenerator.apply(FlowableInternalHelper.java:35)
	at io.reactivex.internal.operators.flowable.FlowableGenerate$GeneratorSubscription.request(FlowableGenerate.java:109)
	at io.reactivex.internal.subscribers.BasicFuseableConditionalSubscriber.request(BasicFuseableConditionalSubscriber.java:152)
	at io.reactivex.internal.subscribers.BasicFuseableConditionalSubscriber.request(BasicFuseableConditionalSubscriber.java:152)
	at io.reactivex.internal.subscribers.BasicFuseableSubscriber.request(BasicFuseableSubscriber.java:153)
	at io.reactivex.internal.subscribers.BasicFuseableSubscriber.request(BasicFuseableSubscriber.java:153)
	at io.reactivex.internal.subscribers.BasicFuseableSubscriber.request(BasicFuseableSubscriber.java:153)
	at io.reactivex.internal.operators.flowable.FlowableWindowTimed$WindowExactBoundedSubscriber.onSubscribe(FlowableWindowTimed.java:355)
	at io.reactivex.internal.subscribers.BasicFuseableSubscriber.onSubscribe(BasicFuseableSubscriber.java:67)
	at io.reactivex.internal.subscribers.BasicFuseableSubscriber.onSubscribe(BasicFuseableSubscriber.java:67)
	at io.reactivex.internal.subscribers.BasicFuseableSubscriber.onSubscribe(BasicFuseableSubscriber.java:67)
	at io.reactivex.internal.subscribers.BasicFuseableConditionalSubscriber.onSubscribe(BasicFuseableConditionalSubscriber.java:66)
	at io.reactivex.internal.subscribers.BasicFuseableConditionalSubscriber.onSubscribe(BasicFuseableConditionalSubscriber.java:66)
	at io.reactivex.internal.operators.flowable.FlowableGenerate.subscribeActual(FlowableGenerate.java:52)
	at io.reactivex.Flowable.subscribe(Flowable.java:14918)
	at io.reactivex.internal.operators.flowable.FlowableMap.subscribeActual(FlowableMap.java:35)
	at io.reactivex.Flowable.subscribe(Flowable.java:14918)
	at io.reactivex.internal.operators.flowable.FlowableMap.subscribeActual(FlowableMap.java:35)
	at io.reactivex.Flowable.subscribe(Flowable.java:14918)
	at io.reactivex.internal.operators.flowable.FlowableFilter.subscribeActual(FlowableFilter.java:37)
	at io.reactivex.Flowable.subscribe(Flowable.java:14918)
	at io.reactivex.internal.operators.flowable.FlowableMap.subscribeActual(FlowableMap.java:37)
	at io.reactivex.Flowable.subscribe(Flowable.java:14918)
	at io.reactivex.internal.operators.flowable.FlowableMap.subscribeActual(FlowableMap.java:37)
	at io.reactivex.Flowable.subscribe(Flowable.java:14918)
	at io.reactivex.internal.operators.flowable.FlowableWindowTimed.subscribeActual(FlowableWindowTimed.java:67)
	at io.reactivex.Flowable.subscribe(Flowable.java:14918)
	at io.reactivex.internal.operators.mixed.FlowableSwitchMapMaybe.subscribeActual(FlowableSwitchMapMaybe.java:57)
	at io.reactivex.Flowable.subscribe(Flowable.java:14918)
	at io.reactivex.Flowable.subscribe(Flowable.java:14865)
	at io.reactivex.internal.operators.observable.ObservableFromPublisher.subscribeActual(ObservableFromPublisher.java:31)
	at io.reactivex.Observable.subscribe(Observable.java:12267)
	at io.reactivex.Observable.subscribe(Observable.java:12253)
	at io.reactivex.Observable.subscribe(Observable.java:12212)
	at no.ssb.rawdata.converter.core.ConverterExecutor.processRawdataMessages(ConverterExecutor.java:160)
	at no.ssb.rawdata.converter.core.ConverterExecutor.onStartup(ConverterExecutor.java:113)
	at no.ssb.rawdata.converter.core.$ConverterExecutorDefinition$$exec1.invokeInternal(Unknown Source)
	at io.micronaut.context.AbstractExecutableMethod.invoke(AbstractExecutableMethod.java:146)
	at io.micronaut.context.DefaultBeanContext$BeanExecutionHandle.invoke(DefaultBeanContext.java:2991)
	at io.micronaut.aop.chain.AdapterIntroduction.intercept(AdapterIntroduction.java:81)
	at io.micronaut.aop.chain.MethodInterceptorChain.proceed(MethodInterceptorChain.java:69)
	at no.ssb.rawdata.converter.core.ConverterExecutor$ApplicationEventListener$onStartup1$Intercepted.onApplicationEvent(Unknown Source)
	at io.micronaut.context.DefaultBeanContext.publishEvent(DefaultBeanContext.java:1145)
	at io.micronaut.http.server.netty.NettyHttpServer.fireStartupEvents(NettyHttpServer.java:507)
	at io.micronaut.http.server.netty.NettyHttpServer.start(NettyHttpServer.java:378)
	at io.micronaut.http.server.netty.NettyHttpServer.start(NettyHttpServer.java:96)
	at io.micronaut.runtime.Micronaut.lambda$start$2(Micronaut.java:70)
	at io.micronaut.runtime.Micronaut$$Lambda$544.0000000035542590.accept(Unknown Source)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at io.micronaut.runtime.Micronaut.start(Micronaut.java:68)
	at no.ssb.rawdata.converter.app.sirius.Application.main(Application.java:12)
Caused by: java.io.IOException: Not a data file.
	at org.apache.avro.file.DataFileStream.initialize(DataFileStream.java:102)
	at org.apache.avro.file.DataFileReader.<init>(DataFileReader.java:97)
	at no.ssb.rawdata.avro.AvroRawdataConsumer.setDataFileReader(AvroRawdataConsumer.java:179)
	... 55 common frames omitted
Caused by: java.io.EOFException: null
	at org.apache.avro.io.BinaryDecoder$InputStreamByteSource.readRaw(BinaryDecoder.java:827)
	at org.apache.avro.io.BinaryDecoder.doReadBytes(BinaryDecoder.java:349)
	at org.apache.avro.io.BinaryDecoder.readFixed(BinaryDecoder.java:302)
	at org.apache.avro.io.Decoder.readFixed(Decoder.java:150)
	at org.apache.avro.file.DataFileStream.initialize(DataFileStream.java:100)
	... 57 common frames omitted
```